### PR TITLE
fix: Drag and Drop Targets

### DIFF
--- a/app/pages/planner/page.tsx
+++ b/app/pages/planner/page.tsx
@@ -161,7 +161,11 @@ export default function Planner() {
                 <div className="text-2xl font-bold">Available Courses</div>
                 <Droppable droppableId={droppableIds.allCourses}>
                   {(provided) => (
-                    <div className="w-80" ref={provided.innerRef} {...provided.droppableProps}>
+                    <div
+                      className="w-80 h-full"
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                    >
                       <CourseList courses={allCourses.course} />
                       {provided.placeholder}
                     </div>
@@ -201,7 +205,11 @@ export default function Planner() {
                 </div>
                 <Droppable droppableId={droppableIds.selected}>
                   {(provided) => (
-                    <div className="w-80" ref={provided.innerRef} {...provided.droppableProps}>
+                    <div
+                      className="w-80 h-full"
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                    >
                       <CourseList courses={selected.course} />
                       {provided.placeholder}
                     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "degree-planner-tpo",
+  "name": "degree-planner",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Made the drag and drop targets extend down to bottom of screen to make it more usable.

### Changes

- Increased height of drop zone (couldn't figure out how to extend width)

### Tests applied

What testing has been applied to validate changes are accurate and correct

- Manual testing

### Issue ticket number(s)

Enter the issue numbers resolved by this pull request

- closes #78 

### Checklist

- [ ] Documented
- [x] Linting tests successful
- [ ] merge updated prod branch into development branch
