### PR TITLE
Refactor/use tailwind base

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,12 +48,22 @@
     }
 
     a {
-        @apply transition-colors;
+        @apply text-cyan-600 no-underline;
+    }
+
+    a:hover,
+    a:focus,
+    a:focus-visible {
+        @apply underline decoration-from-font;
+    }
+
+    header a {
+        @apply text-slate-600 no-underline transition-colors;
     }
 
     header a:hover {
         /* TODO: Make navbar links a component and apply styling there */
-        @apply hover:text-cyan-600;
+        @apply text-cyan-600;
     }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -61,11 +61,13 @@
         @apply underline decoration-from-font;
     }
 
-    header a {
-        @apply text-slate-600 no-underline transition-colors;
+    header a,
+    footer a {
+        @apply text-slate-600 font-medium no-underline transition-colors;
     }
 
-    header a:hover {
+    header a:hover,
+    footer a:hover {
         /* TODO: Make navbar links a component and apply styling there */
         @apply text-cyan-600 no-underline;
     }

--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,11 @@
     label {
         @apply font-semibold text-slate-700;
     }
+
+    nav > a {
+        /* TODO: Make navbar links a component and apply styling there */
+        @apply hover:text-cyan-600 transition-colors;
+    }
 }
 
 .animate-in {

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,6 +47,10 @@
         @apply font-semibold text-slate-700;
     }
 
+    p {
+        @apply mb-4;
+    }
+
     a {
         @apply text-cyan-600 no-underline;
     }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,17 +3,48 @@
 @tailwind utilities;
 
 @layer base {
+    * {
+        @apply border-foreground/20;
+    }
+
     :root {
         --background: 200 20% 98%;
         --btn-background: 200 10% 91%;
         --btn-background-hover: 200 10% 89%;
         --foreground: 200 50% 3%;
     }
-}
 
-@layer base {
-    * {
-        @apply border-foreground/20;
+    .btn {
+        @apply bg-cyan-700 text-base text-cyan-50 font-medium rounded-lg px-4 py-2 cursor-pointer transition-colors;
+    }
+    .btn:hover,
+    .btn:focus,
+    .btn:focus-visible {
+        @apply bg-cyan-600 outline-none;
+    }
+    .btn:active {
+        @apply bg-cyan-700;
+    }
+
+    .btn-green {
+        @apply bg-green-700 text-base text-green-50 font-medium rounded-lg px-4 py-2 cursor-pointer transition-colors;
+    }
+    .btn-green:hover,
+    .btn-green:focus,
+    .btn-green:focus-visible {
+        @apply bg-green-600 outline-none;
+    }
+    .btn-green:active {
+        @apply bg-green-700;
+    }
+
+    .btn:disabled,
+    .btn-green:disabled {
+        @apply opacity-50 cursor-not-allowed;
+    }
+
+    label {
+        @apply font-semibold text-slate-700;
     }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,7 @@
 
     header a:hover {
         /* TODO: Make navbar links a component and apply styling there */
-        @apply text-cyan-600;
+        @apply text-cyan-600 no-underline;
     }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,9 +47,13 @@
         @apply font-semibold text-slate-700;
     }
 
-    nav > a {
+    a {
+        @apply transition-colors;
+    }
+
+    header a:hover {
         /* TODO: Make navbar links a component and apply styling there */
-        @apply hover:text-cyan-600 transition-colors;
+        @apply hover:text-cyan-600;
     }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,48 +35,44 @@ export default async function Index() {
         </Link>
       </section>
 
-      <section className="text-slate-600 body-font my-3">
-        <div className="flex flex-col items-center px-5 py-24 -m-4">
-          <div className="p-4 lg:w-1/2 md:w-full">
-            <div className="flex border-2 rounded-lg border-slate-200 border-opacity-50 p-8 sm:flex-row flex-col">
-              <div className="w-16 h-16 sm:mr-8 sm:mb-0 mb-4 inline-flex items-center justify-center rounded-full bg-slate-100 text-cyan-600 flex-shrink-0">
-                {courseIcon()}
-              </div>
-              <div className="flex-grow">
-                <h2 className="text-slate-900 text-lg title-font font-medium mb-3">Courses</h2>
-                <p className="leading-relaxed text-base">
-                  All the courses from BE(Hons) and BSc are available on our website. You can view
-                  the details, including prerequisites and summaries on the Courses page.
-                </p>
-                <Link
-                  href="/pages/courses"
-                  className="mt-3 text-cyan-600 inline-flex items-center text-2xl font-semibold"
-                >
-                  See courses
-                  {arrowIcon()}
-                </Link>
-              </div>
+      <section className="text-slate-600 my-3">
+        <div className="flex flex-col gap-6 items-center px-5 py-24">
+          <div className="lg:w-1/2 md:w-full flex border-2 rounded-lg border-slate-200 border-opacity-50 p-8 sm:flex-row flex-col">
+            <div className="w-16 h-16 sm:mr-8 sm:mb-0 mb-4 inline-flex items-center justify-center rounded-full bg-slate-100 text-cyan-600 flex-shrink-0">
+              {courseIcon()}
+            </div>
+            <div className="flex-grow">
+              <h2 className="text-slate-900 text-lg title-font font-medium mb-3">Courses</h2>
+              <p className="leading-relaxed text-base">
+                All the courses from BE(Hons) and BSc are available on our website. You can view the
+                details, including prerequisites and summaries on the Courses page.
+              </p>
+              <Link
+                href="/pages/courses"
+                className="mt-3 text-cyan-600 inline-flex items-center text-2xl font-semibold"
+              >
+                See courses
+                {arrowIcon()}
+              </Link>
             </div>
           </div>
-          <div className="p-4 lg:w-1/2 md:w-full">
-            <div className="flex border-2 rounded-lg border-slate-200 border-opacity-50 p-8 sm:flex-row flex-col">
-              <div className="w-16 h-16 sm:mr-8 sm:mb-0 mb-4 inline-flex items-center justify-center rounded-full bg-slate-100 text-cyan-600 flex-shrink-0">
-                {contactIcon()}
-              </div>
-              <div className="flex-grow">
-                <h2 className="text-slate-900 text-lg title-font font-medium mb-3">Contact us</h2>
-                <p className="leading-relaxed text-base">
-                  If you have any questions or messages, you can visit the contact page for more
-                  information.
-                </p>
-                <Link
-                  href="/pages/contact"
-                  className="mt-3 text-cyan-600 inline-flex items-center text-2xl font-semibold"
-                >
-                  Learn more
-                  {arrowIcon()}
-                </Link>
-              </div>
+          <div className="lg:w-1/2 md:w-full flex border-2 rounded-lg border-slate-200 border-opacity-50 p-8 sm:flex-row flex-col">
+            <div className="w-16 h-16 sm:mr-8 sm:mb-0 mb-4 inline-flex items-center justify-center rounded-full bg-slate-100 text-cyan-600 flex-shrink-0">
+              {contactIcon()}
+            </div>
+            <div className="flex-grow">
+              <h2 className="text-slate-900 text-lg title-font font-medium mb-3">Contact us</h2>
+              <p className="leading-relaxed text-base">
+                If you have any questions or messages, you can visit the contact page for more
+                information.
+              </p>
+              <Link
+                href="/pages/contact"
+                className="mt-3 text-cyan-600 inline-flex items-center text-2xl font-semibold"
+              >
+                Learn more
+                {arrowIcon()}
+              </Link>
             </div>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default async function Index() {
           </div>
         </div>
         <Link href="/pages/planner">
-          <button className="flex mx-auto mt-16 text-slate-50 font-medium bg-cyan-700 hover:bg-cyan-600 focus:bg-cyan-600 focus-visible:bg-cyan-600 transition-colors border-0 py-3 px-10 focus:outline-none rounded-full text-lg">
+          <button className="btn flex mx-auto mt-16 py-3 px-10 rounded-full text-lg">
             Plan your degree
           </button>
         </Link>

--- a/app/pages/about/page.tsx
+++ b/app/pages/about/page.tsx
@@ -12,7 +12,7 @@ export default async function About() {
           </p>
         </div>
         <div className="my-8 text-gray-600">
-          <p className="mb-4">
+          <p>
             In 2023, as part of the{' '}
             <a href="https://courseoutline.auckland.ac.nz/dco/course/SOFTENG/310">
               SOFTENG&nbsp;310
@@ -21,13 +21,13 @@ export default async function About() {
             Auckland), the G7s were tasked with building website for students to plan their future
             education.
           </p>
-          <p className="mb-4">
+          <p>
             Degree Planner features a complete list of courses available for the university’s
             Bachelor of Science and Bachelor of Engineering programmes, supporting potential and
             current students in their efforts to view and plan their degree, or map out alternative
             degree plans.
           </p>
-          <p className="mb-4">
+          <p>
             We encourage students to create and share degree plans, and rate courses based on past
             experiences to share and foster the culture at Waipapa Taumata Rau. Students may also
             view entrance requirements and recommended plans for essential courses for the career

--- a/app/pages/about/page.tsx
+++ b/app/pages/about/page.tsx
@@ -14,21 +14,12 @@ export default async function About() {
         <div className="my-8 text-gray-600">
           <p className="mb-4">
             In 2023, as part of the{' '}
-            <a
-              className="text-cyan-600 hover:underline transition-text-decoration"
-              href="https://courseoutline.auckland.ac.nz/dco/course/SOFTENG/310"
-            >
+            <a href="https://courseoutline.auckland.ac.nz/dco/course/SOFTENG/310">
               SOFTENG&nbsp;310
             </a>{' '}
-            paper at{' '}
-            <a
-              className="text-cyan-600 hover:underline transition-text-decoration"
-              href="https://www.auckland.ac.nz"
-            >
-              Waipapa Taumata Rau
-            </a>{' '}
-            (the University of Auckland), the G7s were tasked with building website for students to
-            plan their future education.
+            paper at <a href="https://www.auckland.ac.nz">Waipapa Taumata Rau</a> (the University of
+            Auckland), the G7s were tasked with building website for students to plan their future
+            education.
           </p>
           <p className="mb-4">
             Degree Planner features a complete list of courses available for the university’s

--- a/app/pages/contact/page.tsx
+++ b/app/pages/contact/page.tsx
@@ -10,29 +10,15 @@ export default async function About() {
           <h1 className="text-4xl text-medium font-bold">Contact Us</h1>
           <p className="text-slate-600 font-semibold my-4">
             For feedback and bug reports, the best place to lodge them is{' '}
-            <a
-              className="text-cyan-600 hover:underline transition-text-decoration"
-              href="https://github.com/SOFTENG310-G7/degree-planner"
-            >
-              via GitHub
-            </a>
-            .
+            <a href="https://github.com/SOFTENG310-G7/degree-planner">via GitHub</a>.
           </p>
         </div>
         <div className="mt-4 text-slate-600">
-          <p className="mb-4">
+          <p>
             If there isn’t already an{' '}
-            <a
-              className="text-cyan-600 hover:underline transition-text-decoration"
-              href="https://github.com/SOFTENG310-G7/degree-planner/issues"
-            >
-              open thread
-            </a>{' '}
-            about your query, feel free to open a{' '}
-            <a
-              className="text-cyan-600 hover:underline transition-text-decoration"
-              href="https://github.com/SOFTENG310-G7/degree-planner/issues/new/choose"
-            >
+            <a href="https://github.com/SOFTENG310-G7/degree-planner/issues">open thread</a> about
+            your query, feel free to open a{' '}
+            <a href="https://github.com/SOFTENG310-G7/degree-planner/issues/new/choose">
               new issue
             </a>
             .
@@ -40,13 +26,8 @@ export default async function About() {
           <p>
             If you’re unfamiliar with GitHub, you’re also welcome to contact our volunteer
             developers by email at{' '}
-            <a
-              className="text-cyan-600 hover:underline transition-text-decoration"
-              href="mailto:degreeplanner90@gmail.com"
-            >
-              degreeplanner90@gmail.com
-            </a>
-            , or use the contact form below.
+            <a href="mailto:degreeplanner90@gmail.com">degreeplanner90@gmail.com</a>, or use the
+            contact form below.
           </p>
         </div>
         <ContactForm />

--- a/app/pages/login/page.tsx
+++ b/app/pages/login/page.tsx
@@ -21,9 +21,7 @@ export default function Login() {
               action="/auth/sign-in"
               method="post"
             >
-              <label className="font-semibold text-slate-700" htmlFor="email">
-                Email
-              </label>
+              <label htmlFor="email">Email</label>
               <input
                 id="email"
                 autoComplete="on"
@@ -32,9 +30,7 @@ export default function Login() {
                 placeholder="example@domain.com"
                 required
               />
-              <label className="font-semibold text-slate-700" htmlFor="password">
-                Password
-              </label>
+              <label htmlFor="password">Password</label>
               <input
                 id="password"
                 className="rounded-md px-4 py-2 bg-inherit border mb-6 focus-visible:outline-cyan-600 transition-colors"
@@ -43,9 +39,7 @@ export default function Login() {
                 placeholder="••••••••"
                 required
               />
-              <button className="bg-green-700 hover:bg-green-600 focus:bg-green-760 focus-visible:bg-green-600 active:bg-green-700 focus:outline-none focus-visible:outline-none transition-colors rounded px-4 py-2 text-slate-50 font-medium mb-2">
-                Sign in
-              </button>
+              <button className="btn-green mb-2">Sign in</button>
               <Messages />
             </form>
             <div className="flex-1 flex flex-row w-full justify-center items-center gap-2 text-foreground">
@@ -67,9 +61,7 @@ export default function Login() {
               action="/auth/sign-up"
               method="post"
             >
-              <label className="font-semibold text-slate-700" htmlFor="username">
-                Username
-              </label>
+              <label htmlFor="username">Username</label>
               <input
                 id="username"
                 autoComplete="on"
@@ -78,9 +70,7 @@ export default function Login() {
                 placeholder="bobby123"
                 required
               />
-              <label className="font-semibold text-slate-700" htmlFor="email">
-                Email
-              </label>
+              <label htmlFor="email">Email</label>
               <input
                 id="email"
                 autoComplete="on"
@@ -89,9 +79,7 @@ export default function Login() {
                 placeholder="example@domain.com"
                 required
               />
-              <label className="font-semibold text-slate-700" htmlFor="password">
-                Password
-              </label>
+              <label htmlFor="password">Password</label>
               <input
                 id="password"
                 className="rounded-md px-4 py-2 bg-inherit border mb-6 focus:outline-cyan-600 focus-visible:outline-cyan-600 transition-colors"
@@ -100,9 +88,7 @@ export default function Login() {
                 placeholder="••••••••"
                 required
               />
-              <button className="bg-green-700 hover:bg-green-600 focus:bg-green-760 focus-visible:bg-green-600 active:bg-green-700 focus:outline-none focus-visible:outline-none transition-colors rounded px-4 py-2 text-slate-50 mb-2">
-                Sign up
-              </button>
+              <button className="btn-green mb-2">Sign up</button>
               <Messages />
             </form>
             <div className="flex-1 flex flex-row w-full justify-center items-center gap-2 text-foreground">

--- a/app/pages/profile/page.tsx
+++ b/app/pages/profile/page.tsx
@@ -149,7 +149,7 @@ export default function Profile() {
                 <div
                   key={c.courses.id}
                   onClick={() => handleClick(c.courses)}
-                  className="flex flex-row justify-between mt-4 mb-4 rounded-md py-5 px-5 border-2 border-black
+                  className="flex flex-row justify-between mt-4 mb-4 rounded-md py-5 px-5 border-2 border-slate-500
                   hover:cursor-pointer shadow hover:shadow-lg transition-shadow bg-white"
                 >
                   <p className="pr-6 text-slate-600 text-xl">
@@ -194,7 +194,7 @@ export default function Profile() {
                     key={c.course_code}
                     onClick={() => handleClick(c)}
                     className="flex flex-row justify-between mt-4 mb-4 rounded-md py-5 px-5 border-2 
-                    border-black hover:cursor-pointer shadow hover:shadow-lg transition-shadow bg-white"
+                    border-slate-500 hover:cursor-pointer shadow hover:shadow-lg transition-shadow bg-white"
                   >
                     <p className="pr-6 text-slate-600 text-xl">
                       <span className="font-semibold text-slate-800">{c.course_code}</span>{' '}

--- a/app/pages/profile/page.tsx
+++ b/app/pages/profile/page.tsx
@@ -135,7 +135,7 @@ export default function Profile() {
         </>
       )}
       <div className="flex flex-row justify-between mt-6 text-left ml-12">
-        <p className="font-bold text-3xl">Welcome to your profile page.</p>
+        <h1 className="font-bold text-3xl">Welcome to your profile</h1>
         <div className="mr-12">
           <LogoutButton />
         </div>
@@ -177,7 +177,7 @@ export default function Profile() {
         <div className="flex flex-col w-1/2 mr-12">
           {savedCourses ? (
             <div className="mt-12 text-left ml-12">
-              <p className="mb-5 font-bold text-2xl">Degree Plan</p>
+              <p className="mb-5 font-bold text-2xl">Degree plan</p>
               {savedCourses.course.map((c) => (
                 <div key={c.course_code}>
                   <div className="absolute right-0 mt-[25px] mr-16">
@@ -195,8 +195,9 @@ export default function Profile() {
                     className="flex flex-row justify-between mt-4 mb-4 rounded-md py-5 px-5 border-2 
                     border-black hover:cursor-pointer shadow hover:shadow-lg transition-shadow bg-white"
                   >
-                    <p className="pr-6 font-size text-xl">
-                      {c.course_code} - {c.title}
+                    <p className="pr-6 text-slate-600 text-xl">
+                      <span className="font-semibold text-slate-800">{c.course_code}</span>{' '}
+                      {c.title}
                     </p>
                   </div>
                 </div>

--- a/app/pages/profile/page.tsx
+++ b/app/pages/profile/page.tsx
@@ -134,17 +134,15 @@ export default function Profile() {
           <Popup openedData={openedData} closePopup={closePopup} />
         </>
       )}
-      <div className="flex flex-row justify-between mt-6 text-left ml-12">
-        <h1 className="font-bold text-3xl">Welcome to your profile</h1>
-        <div className="mr-12">
-          <LogoutButton />
-        </div>
+      <div className="flex flex-row justify-between mt-6 text-left mx-12">
+        <h1 className="font-semibold text-3xl">Welcome to your profile</h1>
+        <LogoutButton />
       </div>
       <div className="flex flex-row">
         <div className="flex flex-col w-1/2 mr-10">
           {courses.length !== 0 ? (
             <div className="mt-12 text-left ml-12">
-              <p className="mb-5 font-bold text-2xl">Course ratings</p>
+              <p className="mb-5 font-semibold text-2xl">Course ratings</p>
               {courses.map((c) => (
                 <div
                   key={c.courses.id}
@@ -178,7 +176,7 @@ export default function Profile() {
         <div className="flex flex-col w-1/2 mr-12">
           {savedCourses ? (
             <div className="mt-12 text-left ml-12">
-              <p className="mb-5 font-bold text-2xl">Degree plan</p>
+              <p className="mb-5 font-semibold text-2xl">Degree plan</p>
               {savedCourses.course.map((c) => (
                 <div key={c.course_code}>
                   <div className="absolute right-0 mt-[25px] mr-16">

--- a/app/pages/profile/page.tsx
+++ b/app/pages/profile/page.tsx
@@ -144,7 +144,7 @@ export default function Profile() {
         <div className="flex flex-col w-1/2 mr-10">
           {courses.length !== 0 ? (
             <div className="mt-12 text-left ml-12">
-              <p className="mb-5 font-bold text-2xl">Courses Ratings</p>
+              <p className="mb-5 font-bold text-2xl">Course ratings</p>
               {courses.map((c) => (
                 <div
                   key={c.courses.id}
@@ -152,8 +152,9 @@ export default function Profile() {
                   className="flex flex-row justify-between mt-4 mb-4 rounded-md py-5 px-5 border-2 border-black
                   hover:cursor-pointer shadow hover:shadow-lg transition-shadow bg-white"
                 >
-                  <p className="pr-6 font-size text-xl">
-                    {c.courses.course_code} - {c.courses.title}
+                  <p className="pr-6 text-slate-600 text-xl">
+                    <span className="font-semibold text-slate-800">{c.courses.course_code}</span>{' '}
+                    {c.courses.title}
                   </p>
                   <div className="flex">
                     {[...Array(5)].map((star, index) => {

--- a/app/pages/resetPasswordSuccess/page.tsx
+++ b/app/pages/resetPasswordSuccess/page.tsx
@@ -21,7 +21,7 @@ export default function resetPasswordSucess() {
             placeholder="••••••••"
             required
           />
-          <button className="bg-green-700 rounded px-4 py-2 text-white mb-2">Reset</button>
+          <button className="btn-green">Reset</button>
         </form>
         <Messages />
       </div>

--- a/app/pages/sendResetEmail/page.tsx
+++ b/app/pages/sendResetEmail/page.tsx
@@ -11,9 +11,7 @@ export default function sendResetEmail() {
           action="/auth/password-reset-email"
           method="post"
         >
-          <label className="text-md" htmlFor="email">
-            Email
-          </label>
+          <label htmlFor="email">Email</label>
           <input
             id="email"
             autoComplete="on"
@@ -22,9 +20,7 @@ export default function sendResetEmail() {
             placeholder="example@domain.com"
             required
           />
-          <button className="bg-green-700 rounded px-4 py-2 text-white mb-2">
-            Send Password Reset Email
-          </button>
+          <button className="btn-green">Send password reset email</button>
         </form>
         <Messages />
       </div>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -85,10 +85,7 @@ const ContactForm: React.FC = () => {
         ></textarea>
 
         <div className="mb-6">
-          <button
-            type="submit"
-            className="w-full px-3 py-4 font-medium text-slate-50 bg-cyan-700 hover:bg-cyan-600 rounded-md active:bg-cyan-700 focus:bg-cyan-600 focus:outline-none transition-colors"
-          >
+          <button type="submit" className="btn w-full px-3 py-4">
             Send message
           </button>
         </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,25 +2,16 @@ import Link from 'next/link';
 
 export default function Footer() {
   return (
-    <footer className="border-t border-gray-300 text-gray-600 body-font">
-      <div className="container px-5 py-8 mx-auto flex items-center sm:flex-row flex-col">
-        <Link
-          href="/"
-          className="flex title-font font-medium items-center md:justify-start justify-center text-slate-900"
-        >
-          <p className="ml-3 text-xl font-bold">UoA Degree Planner</p>
-        </Link>
-        <p className="text-sm text-slate-500 sm:ml-4 sm:pl-4 sm:border-l-2 sm:border-gray-200 sm:py-2 sm:mt-0 mt-4">
-          ©&nbsp;2023 SOFTENG&nbsp;310 The G7
-        </p>
-        <a
-          href="https://www.auckland.ac.nz/"
-          target="_blank"
-          className="inline-flex sm:ml-auto sm:mt-0 mt-4 justify-center sm:justify-start hover:underline"
-        >
-          <p>The University of Auckland</p>
-        </a>
-      </div>
+    <footer className="flex flex-row justify-between items-baseline border-t border-slate-300 text-slate-600 px-16 py-7 tracking-wide min-h-[12rem]">
+      <Link href="/" className="flex text-xl font-semibold text-cyan-900 tracking-tight">
+        Degree Planner
+      </Link>
+      <p className="text-sm text-slate-500">
+        ©&nbsp;2023 SOFTENG&nbsp;310 Degree Planner Contributors
+      </p>
+      <a href="https://www.auckland.ac.nz" target="_blank">
+        University of Auckland
+      </a>
     </footer>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,15 +3,24 @@ import Link from 'next/link';
 export default function Footer() {
   return (
     <footer className="flex flex-row flex-wrap justify-between items-baseline border-t border-slate-300 text-slate-600 px-16 py-7 tracking-wide min-h-[12rem]">
-      <Link href="/" className="flex text-xl font-semibold text-cyan-900 tracking-tight">
-        Degree Planner
-      </Link>
+      <div>
+        <Link href="/" className="flex text-xl font-semibold text-cyan-900 tracking-tight">
+          Degree Planner
+        </Link>
+        <Link
+          href="https://www.auckland.ac.nz"
+          className="font-medium text-slate-500"
+          target="_blank"
+        >
+          University of Auckland
+        </Link>
+      </div>
       <p className="text-sm text-slate-500">
         ©&nbsp;2023 SOFTENG&nbsp;310 Degree Planner Contributors
       </p>
-      <a href="https://www.auckland.ac.nz" target="_blank">
-        University of Auckland
-      </a>
+      <Link href="https://github.com/SOFTENG310-G7/degree-planner" target="_blank">
+        GitHub
+      </Link>
     </footer>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,14 +4,8 @@ export default function Footer() {
   return (
     <footer className="flex flex-row flex-wrap justify-between items-baseline border-t border-slate-300 text-slate-600 px-16 py-7 tracking-wide min-h-[12rem]">
       <div>
-        <Link href="/" className="flex text-xl font-semibold text-cyan-900 tracking-tight">
-          Degree Planner
-        </Link>
-        <Link
-          href="https://www.auckland.ac.nz"
-          className="font-medium text-slate-500"
-          target="_blank"
-        >
+        <p className="text-2xl font-semibold text-cyan-900 tracking-tight mb-0">Degree Planner</p>
+        <Link href="https://www.auckland.ac.nz" className="text-slate-500" target="_blank">
           University of Auckland
         </Link>
       </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function Footer() {
   return (
-    <footer className="flex flex-row justify-between items-baseline border-t border-slate-300 text-slate-600 px-16 py-7 tracking-wide min-h-[12rem]">
+    <footer className="flex flex-row flex-wrap justify-between items-baseline border-t border-slate-300 text-slate-600 px-16 py-7 tracking-wide min-h-[12rem]">
       <Link href="/" className="flex text-xl font-semibold text-cyan-900 tracking-tight">
         Degree Planner
       </Link>

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,9 +1,7 @@
 export default function LogoutButton() {
   return (
     <form action="/auth/sign-out" method="post">
-      <button className="text-slate-50 bg-cyan-700 hover:bg-cyan-600 font-medium rounded-lg text-base px-4 py-2">
-        Log out
-      </button>
+      <button className="btn">Log out</button>
     </form>
   );
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -11,7 +11,7 @@ export default async function NavBar() {
   } = await supabase.auth.getUser();
 
   return (
-    <header className="flex flex-row px-16 py-7 items-baseline justify-between border-b-2 border-b-slate-300 tracking-wide shadow">
+    <header className="flex flex-row flex-wrap px-16 py-7 items-baseline justify-between border-b-2 border-b-slate-300 tracking-wide shadow">
       <Link
         href="/"
         className="flex text-xl font-semibold items-baseline text-cyan-900 tracking-tight mb-4 md:mb-0"

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -22,7 +22,7 @@ export default async function NavBar() {
           </Link>
 
           <nav className="md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-slate-400 font-medium flex flex-row gap-4 items-center text-base justify-center [&>a]:px-1">
-            <Link href="/pages/courses" className={'hover:text-cyan-600 transition-colors'}>
+            <Link href="/pages/courses" className="hover:text-cyan-600 transition-colors">
               Courses
             </Link>
             <Link href="/pages/planner" className="hover:text-cyan-600 transition-colors">

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -11,7 +11,7 @@ export default async function NavBar() {
   } = await supabase.auth.getUser();
 
   return (
-    <header className="flex flex-row px-16 py-7 items-baseline justify-between font-medium border-b-2 border-b-slate-300 tracking-wide shadow">
+    <header className="flex flex-row px-16 py-7 items-baseline justify-between border-b-2 border-b-slate-300 tracking-wide shadow">
       <Link
         href="/"
         className="flex text-xl font-semibold items-baseline text-cyan-900 tracking-tight mb-4 md:mb-0"

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -18,32 +18,21 @@ export default async function NavBar() {
             href="/"
             className="flex title-font font-medium items-center text-slate-900 mb-4 md:mb-0"
           >
-            <span className="ml-3 text-xl font-semibold">UoA Degree Planner</span>
+            <span className="text-xl font-semibold">UoA Degree Planner</span>
           </Link>
 
           <nav className="md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-slate-400 font-medium flex flex-row gap-4 items-center text-base justify-center [&>a]:px-1">
-            <Link href="/pages/courses" className="hover:text-cyan-600 transition-colors">
-              Courses
-            </Link>
-            <Link href="/pages/planner" className="hover:text-cyan-600 transition-colors">
-              Degree Planner
-            </Link>
-            <Link href="/pages/about" className="hover:text-cyan-600 transition-colors">
-              About
-            </Link>
-            <Link href="/pages/contact" className="hover:text-cyan-600 transition-colors">
-              Contact
-            </Link>
+            {/* TODO: Make navbar links a component and apply styling there */}
+            <Link href="/pages/courses">Courses</Link>
+            <Link href="/pages/planner">Degree Planner</Link>
+            <Link href="/pages/about">About</Link>
+            <Link href="/pages/contact">Contact</Link>
           </nav>
           <div className="font-medium">
             {user ? (
-              <Link href="/pages/profile" className="hover:text-cyan-600">
-                {user.email}
-              </Link>
+              <Link href="/pages/profile">{user.email}</Link>
             ) : (
-              <Link href="/pages/login" className="hover:text-cyan-600">
-                Login
-              </Link>
+              <Link href="/pages/login">Login</Link>
             )}
           </div>
         </div>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -11,10 +11,10 @@ export default async function NavBar() {
   } = await supabase.auth.getUser();
 
   return (
-    <header className="flex flex-row px-16 py-7 items-baseline justify-between text-slate-600 font-medium border-b-2 border-b-slate-300 tracking-wide shadow">
+    <header className="flex flex-row px-16 py-7 items-baseline justify-between font-medium border-b-2 border-b-slate-300 tracking-wide shadow">
       <Link
         href="/"
-        className="flex text-xl font-semibold items-baseline text-cyan-900 traking-normal mb-4 md:mb-0"
+        className="flex text-xl font-semibold items-baseline text-cyan-900 tracking-tight mb-4 md:mb-0"
       >
         Degree Planner
       </Link>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -11,33 +11,27 @@ export default async function NavBar() {
   } = await supabase.auth.getUser();
 
   return (
-    <div className="navbar">
-      <header className="text-slate-600 body-font">
-        <div className="container mx-auto flex flex-wrap p-5 my-3 flex-col md:flex-row items-center">
-          <Link
-            href="/"
-            className="flex title-font font-medium items-center text-slate-900 mb-4 md:mb-0"
-          >
-            <span className="text-xl font-semibold">UoA Degree Planner</span>
-          </Link>
+    <header className="flex flex-row px-16 py-7 items-baseline justify-between text-slate-600 font-medium border-b-2 border-b-slate-300 tracking-wide shadow">
+      <Link
+        href="/"
+        className="flex text-xl font-semibold items-baseline text-cyan-900 traking-normal mb-4 md:mb-0"
+      >
+        Degree Planner
+      </Link>
 
-          <nav className="md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-slate-400 font-medium flex flex-row gap-4 items-center text-base justify-center [&>a]:px-1">
-            {/* TODO: Make navbar links a component and apply styling there */}
-            <Link href="/pages/courses">Courses</Link>
-            <Link href="/pages/planner">Degree Planner</Link>
-            <Link href="/pages/about">About</Link>
-            <Link href="/pages/contact">Contact</Link>
-          </nav>
-          <div className="font-medium">
-            {user ? (
-              <Link href="/pages/profile">{user.email}</Link>
-            ) : (
-              <Link href="/pages/login">Login</Link>
-            )}
-          </div>
-        </div>
-        <hr className="h-px bg-slate-300 border-0 dark:bg-slate-300 m-0" />
-      </header>
-    </div>
+      <nav className="flex flex-row gap-6 items-baseline text-base">
+        {/* TODO: Make navbar links a component and apply styling there */}
+        <Link href="/pages/courses">Courses</Link>
+        <Link href="/pages/planner">Degree Planner</Link>
+        <Link href="/pages/about">About</Link>
+        <Link href="/pages/contact">Contact</Link>
+      </nav>
+
+      {user ? (
+        <Link href="/pages/profile">{user.email}</Link>
+      ) : (
+        <Link href="/pages/login">Login</Link>
+      )}
+    </header>
   );
 }

--- a/components/Popup.tsx
+++ b/components/Popup.tsx
@@ -15,7 +15,7 @@ const Popup: React.FC<PopupProps> = ({ openedData, closePopup }) => {
     >
       <div className="border-2 border-grey-300 rounded-lg mx-[200px] my-[300px] bg-white">
         <button className="text-right w-full p-2" onClick={closePopup}>
-          x
+          ×
         </button>
         <div
           className="flex flex-col px-10 pb-10"


### PR DESCRIPTION
### Changes

Previously we had a lot of duplicate styling, where the same Tailwind classes were applied to every instances of a particular element (e.g. `<button>` or `<label>`).

Where appropriate, I’ve tried to define a Tailwind `@base` style, and just add the one class to an element.

(Quite frankly, in the context of React + Tailwind, even `<button>`s should really be a React component that returns a single `<button>` styled with Tailwind classes.)

### Tests applied

Manual, by eye.

### Issue ticket number(s)

Works toward addressing #87

### Checklist

- [x] Documented
- [x] Linting tests successful
- [x] merge updated prod branch into development branch
